### PR TITLE
Replaced ‘hr’ elements with divs with border bottom for easier customization.

### DIFF
--- a/app/assets/stylesheets/abstractor/abstractor_abstractions.css
+++ b/app/assets/stylesheets/abstractor/abstractor_abstractions.css
@@ -51,7 +51,7 @@
   margin: 0.1em 0 0.25em !important;
 }
 
-.abstractor_abstractions fieldset .abstraction_schema_name,
+.abstractor_abstractions fieldset .abstractor_abstraction_schema_name,
 .abstractor_abstractions fieldset .abstractor_suggestion_status,
 .abstractor_abstractions fieldset .abstractor_suggestion_sources {
   display: inline;
@@ -90,7 +90,7 @@
   width: 425.75px;
 }
 
-* html .abstractor_abstractions fieldset .abstraction_schema_name,
+* html .abstractor_abstractions fieldset .abstractor_abstraction_schema_name,
 * html .abstractor_abstractions fieldset .abstractor_suggestion_status,
 * html .abstractor_abstractions fieldset .abstractor_suggestion_sources,
 * html .abstractor_abstractions fieldset .abstraction_edit_abstraction_actions,
@@ -105,7 +105,7 @@
   clear: both;
 }
 
-.abstractor_abstractions fieldset .abstraction_schema_name {
+.abstractor_abstractions fieldset .abstractor_abstraction_schema_name {
   font-weight: bold;
   margin-bottom: 0.3em;
 }
@@ -235,7 +235,7 @@ span.tooltip_img {
   font-style:italic
 }
 
-.abstractor_abstraction_actions {
+.abstractor_abstraction_actions  a{
   float: right;
 }
 .abstractor_abstraction_actions a {
@@ -273,4 +273,11 @@ ul.abstractor_suggestion_status_group {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+.abstractor_abstractions_header,
+.abstractor_abstraction_group_member,
+.abstractor_abstraction_group_actions {
+  border-bottom: 1px solid #dddddd;
+  overflow: auto;
+  padding-bottom: 0.25em;
 }

--- a/app/views/abstractor/abstractor_abstraction_groups/_form.html.haml
+++ b/app/views/abstractor/abstractor_abstraction_groups/_form.html.haml
@@ -1,14 +1,13 @@
 - abstractor_abstraction_group ||= @abstractor_abstraction_group
 
 .abstractor_abstraction_group
-  - abstractor_abstractions = abstractor_abstraction_group.abstractor_abstractions.not_deleted.joins(:abstractor_subject => :abstractor_subject_group_member).order('abstractor_subject_group_members.display_order')
-  - abstractor_abstractions.each_with_index do |abstractor_abstraction, index|
-    %div{ class: "abstractor_abstraction #{Abstractor::Utility.dehumanize(abstractor_abstraction.abstractor_subject.abstractor_abstraction_schema.predicate)} #{'abstractor_bottom_border' if index < abstractor_abstractions.length - 1}" }
-      = render :partial => 'abstractor/abstractor_abstractions/fields', :locals => {:abstractor_abstraction => abstractor_abstraction}
-  %hr
-  .abstractor_abstraction_actions
+  .abstractor_abstraction_group_member
+    - abstractor_abstractions = abstractor_abstraction_group.abstractor_abstractions.not_deleted.joins(:abstractor_subject => :abstractor_subject_group_member).order('abstractor_subject_group_members.display_order')
+    - abstractor_abstractions.each_with_index do |abstractor_abstraction, index|
+      %div{ class: "abstractor_abstraction #{Abstractor::Utility.dehumanize(abstractor_abstraction.abstractor_subject.abstractor_abstraction_schema.predicate)} #{'abstractor_bottom_border' if index < abstractor_abstractions.length - 1}" }
+        = render :partial => 'abstractor/abstractor_abstractions/fields', :locals => {:abstractor_abstraction => abstractor_abstraction}
+  .abstractor_abstraction_group_actions.abstractor_abstraction_actions
     = link_to 'Not applicable group ', Abstractor::UserInterface.abstractor_relative_path(abstractor.abstractor_abstraction_group_path(abstractor_abstraction_group, abstractor_abstraction_value: 'not applicable')), data: { confirm: 'Are you sure?'} , method: :put, class: "abstractor_group_not_applicable_all_link", remote: true
     = link_to 'Unknown group ', Abstractor::UserInterface.abstractor_relative_path(abstractor.abstractor_abstraction_group_path(abstractor_abstraction_group, abstractor_abstraction_value: 'unknown')), data: { confirm: 'Are you sure?'}, method: :put, class: 'abstractor_group_unknown_all_link', remote: true
     - if abstractor_abstraction_group.removable?
       = link_to 'Delete group', Abstractor::UserInterface.abstractor_relative_path(abstractor.abstractor_abstraction_group_path(abstractor_abstraction_group)), data: { confirm: 'Are you sure?'}, method: :delete, class: "abstractor_group_delete_link", remote: true
-  %hr

--- a/app/views/abstractor/abstractor_abstractions/_fields.html.haml
+++ b/app/views/abstractor/abstractor_abstractions/_fields.html.haml
@@ -6,7 +6,7 @@
   - about = abstractor_abstraction.about
 
   .abstractor_abstraction_display
-    .abstraction_schema_name
+    .abstractor_abstraction_schema_name
       = abstractor_abstraction_schema.display_name
     .abstractor_abstraction_value
       - if rejected_suggestions.length == abstractor_suggestions.length

--- a/app/views/abstractor/abstractor_abstractions/_grouped_abstractions_list.html.haml
+++ b/app/views/abstractor/abstractor_abstractions/_grouped_abstractions_list.html.haml
@@ -1,20 +1,23 @@
-- abstractor_subject_groups = about.class.abstractor_subject_groups(namespace_type: namespace_type, namespace_id: namespace_id)
-- abstractor_subject_groups.each do |abstractor_subject_group|
-  .abstractor_subject_groups_container
-    %b= abstractor_subject_group.name
-    %fieldset
-      .abstraction_schema_name
-        %b Name
-      .abstractor_abstraction_value
-        %b Value
-      .abstractor_suggestions
-        .abstractor_suggestion_values
-          %b Suggestions
-        .abstractor_suggestion_status
-          %b Status
-      %hr
-      - abstractor_abstraction_groups = about.abstractor_abstraction_groups_by_namespace(namespace_type: namespace_type, namespace_id: namespace_id, abstractor_subject_group_id: abstractor_subject_group.id)
-      - abstractor_abstraction_groups.each do |abstractor_abstraction_group|
-        = render partial: 'abstractor/abstractor_abstraction_groups/form', locals: {abstractor_abstraction_group: abstractor_abstraction_group}
-      = link_to 'Add group', Abstractor::UserInterface.abstractor_relative_path(abstractor.abstractor_abstraction_groups_path(about_id: about.id, about_type: about.class.name, abstractor_subject_group_id: abstractor_subject_group.id)),  data: { confirm: 'Are you sure?'}, method: :post, class: 'abstractor_group_add_link', remote: true
+.abstractor_abstractions_grouped
+  - abstractor_subject_groups = about.class.abstractor_subject_groups(namespace_type: namespace_type, namespace_id: namespace_id)
+  - abstractor_subject_groups.each do |abstractor_subject_group|
+    .abstractor_subject_groups_container
+      %b= abstractor_subject_group.name
+      %fieldset
+        .abstractor_abstractions_header
+          .abstractor_abstraction_schema_name
+            %b Name
+          .abstractor_abstraction_value
+            %b Value
+          .abstractor_suggestions
+            .abstractor_suggestion_values
+              %b Suggestions
+            .abstractor_suggestion_status
+              %b Status
+        .clear
+        .abstractor_abstractions_body
+          - abstractor_abstraction_groups = about.abstractor_abstraction_groups_by_namespace(namespace_type: namespace_type, namespace_id: namespace_id, abstractor_subject_group_id: abstractor_subject_group.id)
+          - abstractor_abstraction_groups.each do |abstractor_abstraction_group|
+            = render partial: 'abstractor/abstractor_abstraction_groups/form', locals: {abstractor_abstraction_group: abstractor_abstraction_group}
+          = link_to 'Add group', Abstractor::UserInterface.abstractor_relative_path(abstractor.abstractor_abstraction_groups_path(about_id: about.id, about_type: about.class.name, abstractor_subject_group_id: abstractor_subject_group.id)),  data: { confirm: 'Are you sure?'}, method: :post, class: 'abstractor_group_add_link', remote: true
 .clear

--- a/app/views/abstractor/abstractor_abstractions/_ungrouped_abstractions_list.html.haml
+++ b/app/views/abstractor/abstractor_abstractions/_ungrouped_abstractions_list.html.haml
@@ -2,19 +2,21 @@
   - ungrouped_subjects = about.class.abstractor_subjects(grouped: false, namespace_type: namespace_type, namespace_id: namespace_id)
   - if ungrouped_subjects.any?
     %fieldset
-      .abstraction_schema_name
-        %b Name
-      .abstractor_abstraction_value
-        %b Value
-      .abstractor_suggestions
-        .abstractor_suggestion_values
-          %b Suggestions
-        .abstractor_suggestion_status
-          %b Status
-      %hr
-      - ungrouped_subjects.each_with_index do |ungrouped_subject, index|
-        - abstractor_abstractions = ungrouped_subject.abstractor_abstractions.not_deleted.where(:about_id => about.id)
-        - abstractor_abstractions.each do |abstractor_abstraction|
-          %div{ class: "abstractor_abstraction #{Abstractor::Utility.dehumanize(abstractor_abstraction.abstractor_subject.abstractor_abstraction_schema.predicate)} #{'abstractor_bottom_border' if index < ungrouped_subjects.length - 1}" }
-            = render :partial => 'abstractor/abstractor_abstractions/fields', :locals => {:abstractor_abstraction => abstractor_abstraction}
+      .abstractor_abstractions_header
+        .abstractor_abstraction_schema_name
+          %b Name
+        .abstractor_abstraction_value
+          %b Value
+        .abstractor_suggestions
+          .abstractor_suggestion_values
+            %b Suggestions
+          .abstractor_suggestion_status
+            %b Status
+      .clear
+      .abstractor_abstractions_body
+        - ungrouped_subjects.each_with_index do |ungrouped_subject, index|
+          - abstractor_abstractions = ungrouped_subject.abstractor_abstractions.not_deleted.where(:about_id => about.id)
+          - abstractor_abstractions.each do |abstractor_abstraction|
+            %div{ class: "abstractor_abstraction #{Abstractor::Utility.dehumanize(abstractor_abstraction.abstractor_subject.abstractor_abstraction_schema.predicate)} #{'abstractor_bottom_border' if index < ungrouped_subjects.length - 1}" }
+              = render :partial => 'abstractor/abstractor_abstractions/fields', :locals => {:abstractor_abstraction => abstractor_abstraction}
 .clear

--- a/app/views/abstractor/abstractor_abstractions/edit.html.haml
+++ b/app/views/abstractor/abstractor_abstractions/edit.html.haml
@@ -3,7 +3,7 @@
 
 .abstractor_abstraction_edit
   = form_for abstractor_abstraction, url: Abstractor::UserInterface.abstractor_relative_path(abstractor.abstractor_abstraction_path(abstractor_abstraction)), method: :put, :remote => true do |f|
-    .abstraction_schema_name
+    .abstractor_abstraction_schema_name
       = abstraction_schema.display_name
     .abstraction_edit_abstraction_value
       - case abstraction_schema.abstractor_object_type.value


### PR DESCRIPTION
Replaced ‘hr’ elements with divs with border bottom for easier customization.
Replaced ‘abstraction_schema_name’ class with ‘abstractor_abstraction_schema_name’
